### PR TITLE
Django Admin create_cache_table issue

### DIFF
--- a/src/hydro/cache/mysql_cache.py
+++ b/src/hydro/cache/mysql_cache.py
@@ -24,7 +24,8 @@ class MySQLCache(CacheBase):
         except Exception, err:
             if err.args[0] in (1146, 1049):  # 1146 - table doesn't exist, 1049 - unknown database?
                 cmd = createcachetable.Command().execute(cache_table,
-                                                         **{'database': cache_db})
+                                                         **{'database': cache_db,
+                                                            'verbosity': 2})
             else:
                 raise
 


### PR DESCRIPTION
Pass verbosity flag to handle issue with compatability with django > 1.8.x

This might also be handled by using `call_command` rather than `Command().execute`