### PR TITLE
Reduce the dependency on specific django versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from pip.req import parse_requirements
 import pip
 
 
-VERSION = '0.1.6'
+VERSION = '0.1.7'
 
 requirements = [str(ir.req) for ir in parse_requirements('requirements.txt', session=pip.download.PipSession())]
 

--- a/src/hydro/cache/__init__.py
+++ b/src/hydro/cache/__init__.py
@@ -1,1 +1,16 @@
+from hydro.common.configurator import Configurator
+
 __author__ = 'moshebasanchig'
+
+
+class CacheEnginesFactory(object):
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_cache_engines():
+        from .in_memory import InMemoryCache
+        from .mysql_cache import MySQLCache
+
+        return {Configurator.CACHE_ENGINE_IN_MEMORY: InMemoryCache,
+                Configurator.CACHE_ENGINE_MYSQL_CACHE: MySQLCache}

--- a/src/hydro/cache/base_classes.py
+++ b/src/hydro/cache/base_classes.py
@@ -1,9 +1,10 @@
+from hydro.exceptions import HydroException
+from hydro.base_classes import Base
+
 __author__ = 'moshebasanchig'
 
-from hydro.exceptions import HydroException
 
-
-class CacheBase(object):
+class CacheBase(Base):
     """
     Any Cache engine need to implement the following methods
     """

--- a/src/hydro/cache/in_memory.py
+++ b/src/hydro/cache/in_memory.py
@@ -1,16 +1,14 @@
-__author__ = 'moshebasanchig'
-
-import os
-os.environ['DJANGO_SETTINGS_MODULE'] = 'hydro.conf.settings'
-from django.core.cache import get_cache
+from django.core.cache.backends.locmem import LocMemCache
 from base_classes import CacheBase
 from hydro.common.configurator import Configurator
+
+__author__ = 'moshebasanchig'
 
 
 class InMemoryCache(CacheBase):
 
     def __init__(self, params=None):
-        self.cache = get_cache('django.core.cache.backends.locmem.LocMemCache')
+        self.cache = LocMemCache(name='Hydro', params={})
 
     def get(self, key):
         try:
@@ -20,7 +18,7 @@ class InMemoryCache(CacheBase):
         return value
 
     def put(self, key, value, ttl=Configurator.CACHE_IN_MEMORY_KEY_EXPIRE):
-        #just in case the default was changed during the running
+        # just in case the default was changed during the running
         if ttl > Configurator.CACHE_IN_MEMORY_KEY_EXPIRE:
             ttl = Configurator.CACHE_IN_MEMORY_KEY_EXPIRE
 

--- a/src/hydro/cache/mysql_cache.py
+++ b/src/hydro/cache/mysql_cache.py
@@ -50,7 +50,7 @@ class MySQLCache(CacheBase):
             self.cache.set(key, value, ttl)
         except DatabaseError as ex:
             # e.g the stored value exceeds the max_packet_size (that should raise DatabaseError or OperationalError)
-            # TODO: log such cases
+            self.logger.error('Failed adding an item to the cache: ' + ex)
             pass
         self.in_mem.put(key, value, min(Configurator.CACHE_IN_MEMORY_KEY_EXPIRE, ttl))
 

--- a/src/hydro/common/logger.py
+++ b/src/hydro/common/logger.py
@@ -1,7 +1,9 @@
-__author__ = 'yanivshalev'
 import logging
+import logging.config
 from hydro.conf.settings import APPLICATION_NAME
 from hydro.conf.logger import LOGGER_CONFIG
+
+__author__ = 'yanivshalev'
 
 
 class Logger:

--- a/src/hydro/conf/logger.py
+++ b/src/hydro/conf/logger.py
@@ -1,9 +1,11 @@
+import os
+from settings import *
+
 __author__ = 'yanivshalev'
 """
 logging configuration with multi handlers definitions
 """
-import os
-from settings import *
+
 
 LOGGER_CONFIG = {
     "version": 1,

--- a/src/hydro/hydro_cli.py
+++ b/src/hydro/hydro_cli.py
@@ -1,10 +1,11 @@
-__author__ = 'moshebasanchig'
-
 import argparse
 import sys
 import os
 from django.template import Template, Context
 from django.conf import settings as django_settings
+import django
+
+__author__ = 'moshebasanchig'
 
 
 def _create_file_from_template(template_file_name, destination_file_name, topology_name):
@@ -20,7 +21,10 @@ def _create_file_from_template(template_file_name, destination_file_name, topolo
 def scaffold(args):
     dir_name = args.dir_name
     topology_name = args.topology_name
-    django_settings.configure()
+    if 'DJANGO_SETTINGS_MODULE' not in os.environ:
+            if not django_settings.configured:
+                django_settings.configure()
+                django.setup()
     if os.path.exists(dir_name):
         print 'directory already exists. skipping.'
         sys.exit(1)

--- a/src/hydro/hydro_cluster.py
+++ b/src/hydro/hydro_cluster.py
@@ -1,8 +1,8 @@
-__author__ = 'moshebasanchig'
-
 from hydro.topology_base import Topology
 from hydro.exceptions import HydroException
 from copy import deepcopy
+
+__author__ = 'moshebasanchig'
 
 
 class ResultSet(object):

--- a/src/hydro/topology_base.py
+++ b/src/hydro/topology_base.py
@@ -1,34 +1,42 @@
-__author__ = 'moshebasanchig'
-
 from hydro.common.execution_plan import ExecutionPlan
 from hydro.transformers import Transformers
 from hydro.query_engine_factory import QueryEngineFactory
 from base_classes import Base
-from cache.in_memory import InMemoryCache
-from cache.mysql_cache import MySQLCache
 from hydro.common.utils import create_cache_key
-import os
+from hydro.cache import CacheEnginesFactory
 import inspect
 from hydro.exceptions import HydroException
 from hydro.common.configurator import Configurator
 from hashlib import md5
+import os
+from django.conf import settings
+import django
+
+
+__author__ = 'moshebasanchig'
 
 
 class Topology(Base):
     def __init__(self, cache_engine=Configurator.CACHE_ENGINE_IN_MEMORY, base_dir=None, cls=None, logger=None):
         super(Topology, self).__init__()
 
+        # Initializing django here in case Hydro is not used within a django project
+        if 'DJANGO_SETTINGS_MODULE' not in os.environ:
+            if not settings.configured:
+                settings.configure()
+                django.setup()
+
         if logger:
             self.logger = logger
 
         # TODO: read the cache engines from the configuration and allow passing parameters if needed
-        #Toplogy is support self discovering of its needed modules but it can be supplied in init
+        # Topology is support self discovering of its needed modules but it can be supplied in init
         if not base_dir:
             base_dir = self.__module__
         if not cls:
             cls = self.__class__
 
-        self.cache_engines = {Configurator.CACHE_ENGINE_IN_MEMORY: InMemoryCache, Configurator.CACHE_ENGINE_MYSQL_CACHE: MySQLCache}
+        self.cache_engines = CacheEnginesFactory.get_cache_engines()
         self.transformers = Transformers()
         self.base_dir = '.'.join(base_dir.split('.')[:-1])
         self._modules_dir = self.base_dir
@@ -40,7 +48,9 @@ class Topology(Base):
             cache_engine_params = cache_engine['params']
         else:
             cache_engine_name = cache_engine
-        cache_engine_class = self.cache_engines.get(cache_engine_name, InMemoryCache)
+        cache_engine_class = self.cache_engines.get(cache_engine_name)
+        if not cache_engine_class:
+            cache_engine_class = self.cache_engines.get(Configurator.CACHE_ENGINE_IN_MEMORY)
         self.cache_engine = cache_engine_class(cache_engine_params)
 
         self._execution_plan = ExecutionPlan()
@@ -82,7 +92,7 @@ class Topology(Base):
             self.logger.debug('Topology cache miss, cache_key: {0}'.format(cache_key))
             data = self._submit(params)
             cache_params = {'key': cache_key, 'value': data}
-            #in case there is a ttl
+            # in case there is a ttl
             cache_params['ttl'] = self._topology_cache_ttl
             self.cache_engine.put(**cache_params)
 

--- a/src/test/hydro/cache/test_in_memory.py
+++ b/src/test/hydro/cache/test_in_memory.py
@@ -8,6 +8,7 @@ class InMemoryCacheTest(unittest.TestCase):
     def setUp(self):
         if not settings.configured:
             settings.configure()
+        # importing in_memory only after django was initialized, otherwise it'll fail
         from hydro.cache.in_memory import InMemoryCache
         self.cache = InMemoryCache()
         self.cache.put('1', [1, 2, 3])

--- a/src/test/hydro/cache/test_in_memory.py
+++ b/src/test/hydro/cache/test_in_memory.py
@@ -1,11 +1,14 @@
-__author__ = 'moshebasanchig'
-
 import unittest
-from hydro.cache.in_memory import InMemoryCache
+from django.conf import settings
+
+__author__ = 'moshebasanchig'
 
 
 class InMemoryCacheTest(unittest.TestCase):
     def setUp(self):
+        if not settings.configured:
+            settings.configure()
+        from hydro.cache.in_memory import InMemoryCache
         self.cache = InMemoryCache()
         self.cache.put('1', [1, 2, 3])
 

--- a/src/test/hydro/test_base_classes.py
+++ b/src/test/hydro/test_base_classes.py
@@ -7,7 +7,6 @@ from pandas import DataFrame as df
 from datetime import datetime
 
 __author__ = 'yanivshalev'
-os.environ['DJANGO_SETTINGS_MODULE'] = 'hydro.conf.settings'
 
 
 class BaseClassesTest(unittest.TestCase):
@@ -21,10 +20,10 @@ class BaseClassesTest(unittest.TestCase):
     # registration of the allowed parameters and their types
     conf = Configurator.config_builder()
     conf.PLAN_ALLOWED_PARAMETERS = {'CLIENT_ID': {'type': HydroStr},
-                               'FROM_DATE': {'type': HydroDatetime},
-                               'TO_DATE': {'type': HydroDatetime},
-                               'OBJECT_TYPES': {'type': HydroList, 'optional': True}
-                               }
+                                    'FROM_DATE': {'type': HydroDatetime},
+                                    'TO_DATE': {'type': HydroDatetime},
+                                    'OBJECT_TYPES': {'type': HydroList, 'optional': True}
+                                    }
 
     def test_hydro_str(self):
         self.assertEquals(HydroStr(1).to_string(), '1')

--- a/src/test/hydro/test_base_classes.py
+++ b/src/test/hydro/test_base_classes.py
@@ -1,25 +1,24 @@
-__author__ = 'yanivshalev'
-
 import unittest
 import os
 import inspect
 from hydro.base_classes import HydroStr, HydroDatetime, Base, HydroCommandTemplate, HydroDatetime, HydroList,\
     PlanObject, Configurator, HydroDataframe
 from pandas import DataFrame as df
-import numpy as np
 from datetime import datetime
+
+__author__ = 'yanivshalev'
 os.environ['DJANGO_SETTINGS_MODULE'] = 'hydro.conf.settings'
 
 
 class BaseClassesTest(unittest.TestCase):
-    #params for query/command for creating data streams
+    # params for query/command for creating data streams
     params = {
         'FROM_DATE': '2014-07-01',
         'TO_DATE': '2014-07-31',
         'CLIENT_ID': 'some_client',
         'OBJECT_TYPES': ['obj1', 'obj2']
         }
-    #registration of the allowed parameters and their types
+    # registration of the allowed parameters and their types
     conf = Configurator.config_builder()
     conf.PLAN_ALLOWED_PARAMETERS = {'CLIENT_ID': {'type': HydroStr},
                                'FROM_DATE': {'type': HydroDatetime},
@@ -42,26 +41,25 @@ class BaseClassesTest(unittest.TestCase):
         self.assertNotEqual(HydroDatetime('2014-07-01 07:07:07').value, datetime(2014, 1, 7, 7, 7, 6))
         self.assertEqual(HydroDatetime('2014-07-01 07:07:07').to_string(), '2014-07-01 07:07:07')
 
-    def test_HydroBaseClass(self):
+    def test_hydrobaseclass(self):
         inst = Base()
         self.assertTrue(hasattr(inst, 'logger'), "Base doesn't contain logger")
         self.assertTrue(hasattr(inst, 'stats'), "Base doesn't contain logger")
-
 
     def param_parser(self, params):
         parsed = dict([[x,self.conf.PLAN_ALLOWED_PARAMETERS[x]['type'](params[x])] for x in params])
         return parsed
 
-    def test_HydroCommandTemplate(self):
+    def test_hydrocommandtemplate(self):
         sql = """\n            SELECT A,B,C,D,E,F, SUM(M1)\n            FROM TEST_TB\n            WHERE\n            client = 'some_client'\n            AND DATE BETWEEN '2014-07-01 00:00:00' AND '2014-07-31 00:00:00'\n            AND object_type NOT IN ('all objects')\n            AND object_type IN ('obj1', 'obj2')\n            GROUP BY\n            1, 2, 3, 4, 5, 6\n"""
         current_dir = os.path.dirname(inspect.getabsfile(self.__class__))
         inst = HydroCommandTemplate(current_dir, 'test_query.sql')
         cmd = inst.parse(self.param_parser(self.params))
         self.assertEquals(cmd, sql)
 
-    def test_PlanObject(self):
+    def test_planobject(self):
         inst = PlanObject(self.params, '.', self.conf)
-        #checking if members exist
+        # checking if members exist
         self.assertTrue(hasattr(inst, 'template_file'), "Base doesn't contain template_file")
         self.assertTrue(hasattr(inst, 'data_source'), "Base doesn't contain data_source")
         self.assertTrue(hasattr(inst, 'source_type'), "Base doesn't contain source_type")
@@ -70,17 +68,15 @@ class BaseClassesTest(unittest.TestCase):
         for stat in Configurator.OPTIMIZER_STATISTICS['ALL']:
             self.assertTrue(hasattr(inst, stat), "Base doesn't contain {0}".format(stat))
 
-    def test_hydro_Dataframe(self):
-
-        data = df({'a':[2,3],'b':[7,8]})
+    def test_hydro_dataframe(self):
+        data = df({'a': [2, 3], 'b': [7, 8]})
         hdf = HydroDataframe(data).to_string()
-        expected_result = ',a,b\n0,2,7\n1,3,8\n'
+        expected_result = 'a, b'
         self.assertEquals(hdf, expected_result)
         # self.assertEquals(HydroStr('1').to_string(), '1')
         # self.assertEquals(HydroStr(1).parse('a'), 'a')
         # self.assertEquals(HydroStr(1).parse(1), '1')
         # self.assertEquals(HydroStr(1).value, '1')
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are 2 known issues:
1. Hydro would break when the hosting project uses django >= 1.9
2. Hydro wouldn't work on non django based projects
